### PR TITLE
Add support for org-mode variables.

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -57,6 +57,11 @@ This function is called by `org-babel-execute-src-block'"
 
       (insert (buffer-name))
       (with-temp-buffer
+        (dolist (p params)
+          (let ((key (car p))
+                (value (cdr p)))
+            (when (eql key :var)
+              (insert (format ":%s = %s\n" (car value) (cdr value))))))
         (insert body)
         (restclient-http-parse-current-and-do 'restclient-http-do nil t))
 


### PR DESCRIPTION
This allows files like this to work.

```
#+PROPERTY: var term="emacs"

* test
#+BEGIN_SRC restclient
GET http://google.com/?q=:term
#+END_SRC


# Local Variables:
# org-use-property-inheritance: t
# End:
```

When running the value "emacs" shows up in the output showing that it was passed through correctly.
