### PR TITLE
Don't redisplay every 50ms when waiting for HTTP response

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -68,7 +68,7 @@ This function is called by `org-babel-execute-src-block'"
         (restclient-http-parse-current-and-do 'restclient-http-do nil t))
 
       (while restclient-within-call
-        (sit-for 0.05))
+        (sleep-for 0.05))
 
       (goto-char (point-min))
       (when (search-forward (buffer-name) nil t)


### PR DESCRIPTION
I wondered why my cpu fan always turned on when using *long-running* requests. You can reproduce this:

```
#+BEGIN_SRC restclient
GET http://www.fakeresponse.com/api/?sleep=10
#+END_SRC
```
