### PR TITLE
Fixes Restclient encoutered an error message,

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -65,6 +65,7 @@ This function is called by `org-babel-execute-src-block'"
             (when (eql key :var)
               (insert (format ":%s = %s\n" (car value) (cdr value))))))
         (insert body)
+	(goto-char (point-min))
         (restclient-http-parse-current-and-do 'restclient-http-do nil t))
 
       (while restclient-within-call


### PR DESCRIPTION
When using restclient from inside org-plus-contrib 20180319 ob rest-client fails always with a *Restclient encountered an error* message. This is due to the fact that the point on the temporary buffer is not reset before the call to the restclient library. 

This pull request addresses that issue.  