### PR TITLE
Output only the response payload depending on `:results` param

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -77,7 +77,9 @@ This function is called by `org-babel-execute-src-block'"
       (when (search-forward (buffer-name) nil t)
         (error "Restclient encountered an error"))
 
-      (org-babel-restclient-wrap-result))))
+      (if (org-babel-restclient-return-pure-payload-result-p params)
+          (org-babel-restclient-pure-payload-result)
+        (org-babel-restclient-wrap-result)))))
 
 (defun org-babel-restclient-wrap-result ()
   "Wrap the contents of the buffer in an `org-mode' src block."
@@ -86,6 +88,21 @@ This function is called by `org-babel-execute-src-block'"
     (goto-char (point-max))
     (insert "#+END_SRC\n")
     (buffer-string)))
+
+(defun org-babel-restclient-pure-payload-result ()
+  "Just return the payload."
+  (let ((comments-start
+         (save-excursion
+           (while (not (looking-at "//"))
+             (forward-line))
+           (point))))
+    (buffer-substring (point-min) comments-start)))
+
+(defun org-babel-restclient-return-pure-payload-result-p (params)
+  "Return `t' if the `:results' key in PARAMS contains `value' or `table'."
+  (let ((result-type (cdr (assoc :results params))))
+    (when result-type
+      (string-match "value\\|table" result-type))))
 
 (provide 'ob-restclient)
 ;;; ob-restclient.el ends here


### PR DESCRIPTION
Output only the pure payload if the `:results` parameter is set to either
`value` or `table`. This makes it easier to pipe the result from a `restclient`
source block to another block.