### PR TITLE
Add inferring of 'raw' for restclient from  'file' in :results.

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -68,7 +68,8 @@ This function is called by `org-babel-execute-src-block'"
 	(goto-char (point-min))
 	(delete-trailing-whitespace)
 	(goto-char (point-min))
-        (restclient-http-parse-current-and-do 'restclient-http-do nil t))
+      (restclient-http-parse-current-and-do
+       'restclient-http-do (org-babel-restclient-raw-payload-p params) t))
 
       (while restclient-within-call
         (sleep-for 0.05))
@@ -107,6 +108,12 @@ This function is called by `org-babel-execute-src-block'"
   (let ((result-type (cdr (assoc :results params))))
     (when result-type
       (string-match "value\\|table" result-type))))
+
+(defun org-babel-restclient-raw-payload-p (params)
+  "Return t if the `:results' key in PARAMS contain `file'."
+  (let ((result-type (cdr (assoc :results params))))
+    (when result-type
+      (string-match "file" result-type))))
 
 (provide 'ob-restclient)
 ;;; ob-restclient.el ends here


### PR DESCRIPTION
Currently it's impossible to simply fetch a file with restclient, because the raw parameter is hardcoded as nil, and therefore the request info (duration, headers, etc.) is written in the same file.

This PR changes this behaviour to infer if to set raw parameter to t depending on whether :results param contain 'file' value.  