### PR TITLE
No longer search temp buffer for name for error case

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -75,7 +75,7 @@ This function is called by `org-babel-execute-src-block'"
         (sleep-for 0.05))
 
       (goto-char (point-min))
-      (when (search-forward (buffer-name) nil t)
+      (when (equal (buffer-name) (buffer-string))
         (error "Restclient encountered an error"))
 
       (when (or (org-babel-restclient--return-pure-payload-result-p params)


### PR DESCRIPTION
I have a very particular error than I've run across. When the name a the temp buffer (say ` *temp*`) used to capture the response from restclient is present in the api response, then a user-error gets thrown. I've run into this, because I'm messing around with creating an API that deals with the internals of emacs and my first 'endpoint' I'm creating is to list buffers. 

I've put together a short demo of the issue, you'll need `simple-httpd` for it. Run this org src block to start the server
```
#+begin_src elisp
(require 'simple-httpd)
(require 'pp)

(defun httpd/ (proc path &optional params &rest args)
  (with-httpd-buffer proc "plain/text"
    (insert 
      ;; Force the temp buffer's name to be in the API response
     (pp-to-string
      (mapcar #'buffer-name (buffer-list))))))

(setq-local httpd-port 8080)
(httpd-start)
#+end_src
```

Call the server and note the error returned:
```
#+begin_src restclient
GET http://localhost:8080
#+end_src
```


My changes here move to using the full buffer contents for the error case instead of just checking if the buffer-name is *somewhere* in the buffer contents. 