### PR TITLE
Support variable assignment when expanding source blocks

### DIFF
--- a/README.org
+++ b/README.org
@@ -37,6 +37,19 @@
       ,#+END_SRC
     #+END_SRC
 
+  You can pass variables into the block using :var header arguments. For example:
+
+    #+BEGIN_SRC org
+      ,#+name: example_host
+      ,#+BEGIN_SRC elisp
+        "example.com"
+      ,#+END_SRC
+
+      ,#+BEGIN_SRC restclient :var host=example_host :var foo="example" :var bar=42
+        GET http://:host?foo=:foo&bar=:bar
+      ,#+END_SRC
+    #+END_SRC
+
   See [[https://github.com/pashky/restclient.el][restclient.el]] for documentation and examples of usage.
 
 * Author

--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -103,6 +103,16 @@ This function is called by `org-babel-execute-src-block'"
 
       (buffer-string))))
 
+;;;###autoload
+(defun org-babel-variable-assignments:restclient (params)
+  "Return a list of restclient statements assigning the block's variables specified in PARAMS."
+  (mapcar
+   (lambda (pair)
+     (let ((name (car pair))
+           (value (cdr pair)))
+       (format ":%s = %s" name value)))
+   (org-babel--get-vars params)))
+
 (defun org-babel-restclient--wrap-result ()
   "Wrap the contents of the buffer in an `org-mode' src block."
   (let ((mode-name (substring (symbol-name major-mode) 0 -5)))


### PR DESCRIPTION
Hi! I've ran into a small issue with variables set in src block header being lost when expanding it. This provides a fix. I've also added an example that includes header vars usage to the readme, as I had to do some digging to find out how to do it.

Hope this would be useful and thanks for your work on the repo!

---

This make it so block's variables, set as header arguments, would be
assigned when a block is expanded via
'org-babel-expand-src-block'. For example, the following block:

```org
  ,#+begin_src restclient :var foo="hello"
    GET http://example.com?foo=:foo
  ,#+end_src
```

will expand to:

```
:foo = hello
GET http://example.com?foo=:foo
```