### PR TITLE
Fix results to table, value, raw and wrap

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -73,7 +73,7 @@ This function is called by `org-babel-execute-src-block'"
         (delete-trailing-whitespace)
         (goto-char (point-min))
         (restclient-http-parse-current-and-do
-         'restclient-http-do (org-babel-restclient--raw-payload-p params) t))
+         'restclient-http-do (org-babel-restclient--raw-payload-p params) t t))
 
       (while restclient-within-call
         (sleep-for 0.05))

--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -44,7 +44,9 @@
   "Default arguments for evaluating a restclient block.")
 
 (defcustom org-babel-restclient--jq-path "jq"
-  "The path to `jq', for post-processing. Uses the PATH by default")
+  "The path to `jq', for post-processing. Uses the PATH by default"
+  :type '(string)
+  :group 'org-babel)
 
 ;;;###autoload
 (defun org-babel-execute:restclient (body params)
@@ -63,12 +65,10 @@ This function is called by `org-babel-execute-src-block'"
 
       (insert (buffer-name))
       (with-temp-buffer
-        (dolist (p params)
-          (let ((key (car p))
-                (value (cdr p)))
-            (when (eql key :var)
-              (insert (format ":%s = <<\n%s\n#\n" (car value) (cdr value))))))
-        (insert body)
+	(insert
+	 (org-babel-expand-body:generic
+	  body params
+	  (org-babel-variable-assignments:restclient params)))
         (goto-char (point-min))
         (delete-trailing-whitespace)
         (goto-char (point-min))
@@ -94,20 +94,36 @@ This function is called by `org-babel-execute-src-block'"
          (current-buffer)
          t))
 
-       ;; widen if jq but not pure payload
-      (when (and (assq :jq params)
-                 (not (assq :noheaders params))
-                 (not (org-babel-restclient--return-pure-payload-result-p params)))
-        (widen))
-
-      (when (not (org-babel-restclient--return-pure-payload-result-p params))
-        (org-babel-restclient--wrap-result))
-
-      (buffer-string))))
+      (if (member "table" (cdr (assoc :result-params params)))
+	  (let* ((pmax (point-max))
+		 (separator '(4))
+		 (result
+		  (condition-case err
+		      (let ((pmax (point-max)))
+			;; If the buffer is empty, don't bother trying to
+			;; convert the table.
+			(when (> pmax 1)
+			  (org-table-convert-region (point-min) pmax separator)
+			  (delq nil
+				(mapcar (lambda (row)
+					  (and (not (eq row 'hline))
+					       (mapcar #'org-babel-string-read row)))
+					(org-table-to-lisp)))))
+		    (error
+		     (display-warning 'org-babel
+				      (format "Error reading results: %S" err)
+				      :error)
+		     nil))))
+	    (pcase result
+	      (`((,scalar)) scalar)
+	      (`((,_ ,_ . ,_)) result)
+	      (`(,scalar) scalar)
+	      (_ result)))
+	(buffer-string)))))
 
 ;;;###autoload
 (defun org-babel-variable-assignments:restclient (params)
-  "Return a list of restclient statements assigning the block's variables specified in PARAMS."
+  "Return a list of statements assigning variables specified in PARAMS."
   (mapcar
    (lambda (pair)
      (let ((name (car pair))
@@ -134,6 +150,9 @@ This function is called by `org-babel-execute-src-block'"
     (when result-type
       (string-match "value\\|table" result-type))))
 
+(defun org-babel-prep-session:restclient (_session _params)
+  "Return an error because restclient does not support sessions."
+  (error "Restclient does not support sessions"))
 
 (defun org-babel-restclient--raw-payload-p (params)
   "Return t if the `:results' key in PARAMS contain `file'."


### PR DESCRIPTION
Fix result when using one of the following formats : table, value, raw and wrap.
Most of those changes are inspired by org-babel-import-elisp-from-file function.