### PR TITLE
Fix org-babel-variable-assignments:restclient multiline values

### DIFF
--- a/ob-restclient.el
+++ b/ob-restclient.el
@@ -138,8 +138,11 @@ This function is called by `org-babel-execute-src-block'"
   (mapcar
    (lambda (pair)
      (let ((name (car pair))
-           (value (cdr pair)))
-       (format ":%s = %s" name value)))
+           (value (cdr pair))
+	   (format-string ":%s = %s\n"))
+       (when (string-match-p "\n" value)
+	 (setq format-string ":%s = <<\n%s\n#\n"))
+       (format format-string name value)))
    (org-babel--get-vars params)))
 
 (defun org-babel-restclient--wrap-result ()


### PR DESCRIPTION
This should fix #40
For information this is a regression introduced by my commit [Fix results to table, value, raw and wrap](https://github.com/alf/ob-restclient.el/commit/e660eb29b799fb3dd479a580c049fd6fb022d63a)